### PR TITLE
Fixed issues #29297 and #23407

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1159,6 +1159,11 @@ class YoutubeDL(object):
         x_forwarded_for = ie_result.get('__x_forwarded_for_ip')
 
         for i, entry in enumerate(entries, 1):
+            if n_entries > 1:
+                self.to_screen('[download] Downloading %s videos of %s in playlist' % (n_entries, len(playlist)))
+            else:
+                self.to_screen('[download] Downloading %s video of %s in playlist' % (n_entries, len(playlist)))
+
             self.to_screen('[download] Downloading video %s of %s' % (i, n_entries))
             # This __x_forwarded_for_ip thing is a bit ugly but requires
             # minimal changes

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -3,8 +3,11 @@ from __future__ import division, unicode_literals
 import os
 import re
 import sys
+
 import time
 import random
+
+
 
 from ..compat import compat_os_name
 from ..utils import (
@@ -236,7 +239,10 @@ class FileDownloader(object):
 
     def report_destination(self, filename):
         """Report destination filename."""
-        self.to_screen('[download] Destination: ' + filename)
+        self.to_screen('[download] Filename: ' + filename)
+        #print file path of downloaded file
+        self.to_screen('[download] Destination Path: ' + os.path.abspath(filename))
+
 
     def _report_progress_status(self, msg, is_last_line=False):
         fullmsg = '[download] ' + msg

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -3,11 +3,8 @@ from __future__ import division, unicode_literals
 import os
 import re
 import sys
-
 import time
 import random
-
-
 
 from ..compat import compat_os_name
 from ..utils import (

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -259,17 +259,6 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
         self._preferredquality = preferredquality
         self._nopostoverwrites = nopostoverwrites
 
-    def run_ffmpeg(self, path, out_path, codec, more_opts):
-        if codec is None:
-            acodec_opts = []
-        else:
-            acodec_opts = ['-acodec', codec]
-        opts = ['-vn'] + acodec_opts + more_opts
-        try:
-            FFmpegPostProcessor.run_ffmpeg(self, path, out_path, opts)
-        except FFmpegPostProcessorError as err:
-            raise AudioConversionError(err.msg)
-
     def run(self, information):
         path = information['filepath']
 


### PR DESCRIPTION
Fixed issue number #29297 of file path not displaying in terminal, now displays file path after video file title.

Fixed issue number #23407 of outputting total amount of videos when a certain amount of videos is being downloaded from a playlist, ie it now says "downloading 2 of 3 videos from playlist" for example then continues normally.